### PR TITLE
C++ physics in addition to Blueprint

### DIFF
--- a/Source/MMT/Private/MMTPawn.cpp
+++ b/Source/MMT/Private/MMTPawn.cpp
@@ -85,6 +85,11 @@ void AMMTPawn::CustomPhysics(float DeltaTime, FBodyInstance* BodyInstance)
 	MMTPhysicsTick(DeltaTime);
 }
 
+void AMMTPawn::MMTPhysicsTick_Implementation(float SubstepDeltaTime)
+{
+
+}
+
 // Get instance of physics body from component
 FBodyInstance * AMMTPawn::GetBodyInstance(UPrimitiveComponent * PrimitiveComponent)
 {
@@ -92,6 +97,11 @@ FBodyInstance * AMMTPawn::GetBodyInstance(UPrimitiveComponent * PrimitiveCompone
 		return NULL;
 	}
 	return PrimitiveComponent->GetBodyInstance();
+}
+
+void AMMTPawn::MMTAfterPhysicsTick_Implementation(float DeltaTime)
+{
+
 }
 
 // Get MMTPawn transform from BodyInstance as its valid during physics sub-stepping

--- a/Source/MMT/Public/MMTPawn.h
+++ b/Source/MMT/Public/MMTPawn.h
@@ -38,12 +38,14 @@ public:
 	void CustomPhysics(float DeltaTime, FBodyInstance* BodyInstance);
 
 	/* This event is called on every physics tick, including sub-steps. */
-	UFUNCTION(BlueprintImplementableEvent, meta = (DisplayName = "MMT Physics Tick"), Category = "MMT physics sub-stepping")
+	UFUNCTION(BlueprintNativeEvent, meta = (DisplayName = "MMT Physics Tick"), Category = "MMT physics sub-stepping")
 	void MMTPhysicsTick(float SubstepDeltaTime);
-
+	virtual void MMTPhysicsTick_Implementation(float SubstepDeltaTime);
+	
 	/* This event is called ones per frame after physics update. */
-	UFUNCTION(BlueprintImplementableEvent, meta = (DisplayName = "MMT Post-Physics Tick"), Category = "MMT")
+	UFUNCTION(BlueprintNativeEvent, meta = (DisplayName = "MMT Post-Physics Tick"), Category = "MMT")
 	void MMTAfterPhysicsTick(float DeltaTime);
+	virtual void MMTAfterPhysicsTick_Implementation(float DeltaTime);
 
 	/**
 	*	Get world-space transform of this pawn. BodyInstance is used to retrieve transform, its up-to date with physics sub-stepping.


### PR DESCRIPTION
I really like the plugin and its modular architecture! Thank you for all your efforts. While playing around I found a need for both C++ and Blueprint physics calculation.

So I changed from BP-only to C++ implementation stubs, which can be overridden in derived classes.