### PR TITLE
Derived class access + Clang warnings removed

### DIFF
--- a/Source/MMT/Private/MMTTrackAnimationComponent.cpp
+++ b/Source/MMT/Private/MMTTrackAnimationComponent.cpp
@@ -255,7 +255,7 @@ FTransform UMMTTrackAnimationComponent::GetAllignedTransformAlongSplineUsingPosi
 //Perceive it as a angular travel of the tread around a sprocket if full track would be wrapped around sprocket like a snake.
 void UMMTTrackAnimationComponent::CalculateIntAndFracRotationOfTrack(float DeltaPitch)
 {
-	if (!DeltaPitch == 0.0f)
+	if (!(DeltaPitch == 0.0f))
 	{
 		float NewPitch = TreadFractionalTravel + DeltaPitch;
 

--- a/Source/MMT/Public/MMTBPFunctionLibrary.h
+++ b/Source/MMT/Public/MMTBPFunctionLibrary.h
@@ -162,7 +162,7 @@ public:
 			return FString("Invalid Enum");
 		}
 
-		return enumPtr->GetEnumName((int32)Value);
+		return enumPtr->GetNameStringByIndex((int32)Value);
 	}
 
 	//Get readable name of physical surface

--- a/Source/MMT/Public/MMTPawn.h
+++ b/Source/MMT/Public/MMTPawn.h
@@ -55,7 +55,7 @@ public:
 	FTransform MMTGetTransformThisPawn();
 
 
-private:
+protected:
 	// Reference to MMTPawn root component
 	UPROPERTY()
 	UPrimitiveComponent* PawnRootComponent;

--- a/Source/MMT/Public/MMTPhysicalSurfaceFrictionCoefficient.h
+++ b/Source/MMT/Public/MMTPhysicalSurfaceFrictionCoefficient.h
@@ -56,11 +56,11 @@ struct FMMTPhysicalSurfaceFrictionCoefficients
 	}
 
 	//constructor with arguments
-	FMMTPhysicalSurfaceFrictionCoefficients(EPhysicalSurface Surface, float FrictionScale, float RollingFrictionCoefficient)
+	FMMTPhysicalSurfaceFrictionCoefficients(EPhysicalSurface Surface, float FrictionScale, float RollingFrictionCoefficientIn)
 	{
 		PhysicalSurface = Surface;
 		FrictionScaleFactor = FrictionScale;
-		RollingFrictionCoefficient = RollingFrictionCoefficient;
+		RollingFrictionCoefficient = RollingFrictionCoefficientIn;
 	}
 };
 


### PR DESCRIPTION
- Compiling with Clang for Android and Linux resulted in warnings, which I fixed
- Access to physics body from derived classes by making PawnRootComponent protected instead of private