### PR TITLE
Upgrade to newer physics step delegate

### DIFF
--- a/Source/MMT/Public/MMTPawn.h
+++ b/Source/MMT/Public/MMTPawn.h
@@ -20,9 +20,9 @@ public:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-	// Called every frame
-	virtual void Tick(float DeltaSeconds) override;
-	
+	// Called whenever this actor is being removed from a level
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason);
+
 	// Called every frame after physics update
 	void TickPostPhysics(float DeltaSeconds, ELevelTick TickType, FSecondaryTickFunction& ThisTickFunction);
 
@@ -33,9 +33,9 @@ public:
 	UPROPERTY(BlueprintReadOnly)
 	FTransform MMTPawnTransform = FTransform::Identity;
 
-	// Delegate for running custom physics update
-	FCalculateCustomPhysics OnCalculateCustomPhysics;
-	void CustomPhysics(float DeltaTime, FBodyInstance* BodyInstance);
+	// Delegate for physics step
+	FDelegateHandle OnPhysSceneStepHandle;
+	void PhysSceneStep(FPhysScene* PhysScene, uint32 SceneType, float DeltaTime);
 
 	/* This event is called on every physics tick, including sub-steps. */
 	UFUNCTION(BlueprintNativeEvent, meta = (DisplayName = "MMT Physics Tick"), Category = "MMT physics sub-stepping")


### PR DESCRIPTION
This will use newer, UE 4.15+ style delegate for physics updates, no need to bind the custom physics delegate each Tick, so also removed Tick from the Pawn itself (Tick should still work fine on inherited c++ and BP classes).

I didn't test this extensively so make sure to do thorough testing on your MMT_Content before merging the PR :)